### PR TITLE
Upstream headers

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -19,15 +19,15 @@ func TestFromArgs(t *testing.T) {
 		ok   bool
 	}{
 		{"basic", []string{"-name", "foo", "http://example.com"}, true},
-		{"connect to unix", []string{"-name", "foo", "-downstreamUnixAddr=/tmp/foo.sock", "http://example.com"}, true},
-		{"connect to TCP", []string{"-name", "foo", "-downstreamTCPAddr=127.0.0.1:80", "http://example.com"}, true},
+		{"connect to unix", []string{"-name", "foo", "-upstreamUnixAddr=/tmp/foo.sock", "http://example.com"}, true},
+		{"connect to TCP", []string{"-name", "foo", "-upstreamTCPAddr=127.0.0.1:80", "http://example.com"}, true},
 		{"funnel", []string{"-name", "foo", "-funnel=true", "http://example.com"}, true},
 		{"funnelOnly", []string{"-name", "foo", "-funnel=true", "-funnelOnly", "http://example.com"}, true},
 		{"ephemeral", []string{"-name", "foo", "-ephemeral=true", "http://example.com"}, true},
 
 		// Expected to fail:
 		{"no args", []string{}, false},
-		{"both addrs", []string{"-name", "foo", "-downstreamTCPAddr=127.0.0.1:80", "-downstreamUnixAddr=/tmp/foo.sock", "http://example.com"}, false},
+		{"both addrs", []string{"-name", "foo", "-upstreamTCPAddr=127.0.0.1:80", "-upstreamUnixAddr=/tmp/foo.sock", "http://example.com"}, false},
 		{"plaintext on funnel", []string{"-name", "foo", "-plaintext=true", "-funnel", "http://example.com"}, false},
 		{"invalid funnelOnly", []string{"-name", "foo", "-funnelOnly", "http://example.com"}, false},
 		{"invalid destination URL", []string{"-name", "foo", "::--example.com"}, false},

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -101,6 +101,12 @@
             default = false;
           };
 
+          upstreamHeaders = mkOption {
+            description = "Headers to set on requests to upstream.";
+            type = types.attrsOf types.str;
+            default = null;
+          };
+
           toURL = mkOption {
             description = "URL to forward HTTP requests to";
             type = types.str;
@@ -151,7 +157,10 @@
               ${
                 lib.concatMapStringsSep " \\\n" (p: "-prefix \"${p}\"") value.prefixes
               } \
-                     "${value.toURL}"
+              ${
+                lib.concatMapStringsSep " \\\n" (p: "-upstreamHeader ${lib.escapeShellArg p}") (lib.mapAttrsToList (name: value: "${name}: ${value}") value.upstreamHeaders)
+              } \
+                     ${lib.escapeShellArg value.toURL}
             '';
             serviceConfig = {
               DynamicUser = true;

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -104,7 +104,7 @@
           upstreamHeaders = mkOption {
             description = "Headers to set on requests to upstream.";
             type = types.attrsOf types.str;
-            default = null;
+            default = {};
           };
 
           toURL = mkOption {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -134,28 +134,28 @@
             wantedBy = ["multi-user.target"];
             after = ["network-online.target"];
             script = ''
-              exec ${value.package}/bin/tsnsrv -name "${name}" \
+              exec ${value.package}/bin/tsnsrv -name ${lib.escapeShellArg name} \
                      -ephemeral=${lib.boolToString value.ephemeral} \
                      -funnel=${lib.boolToString value.funnel} \
                      -plaintext=${lib.boolToString value.plaintext} \
-                     -listenAddr="${value.listenAddr}" \
-                     -stripPrefix="${lib.boolToString value.stripPrefix}" \
+                     -listenAddr=${lib.escapeShellArg value.listenAddr} \
+                     -stripPrefix=${lib.boolToString value.stripPrefix} \
                      -stateDir="$STATE_DIRECTORY/tsnet-tsnsrv" \
-                     -authkeyPath="${value.authKeyPath}" \
-                     -insecureHTTPS="${lib.boolToString value.insecureHTTPS}" \
-                     -suppressWhois="${lib.boolToString value.suppressWhois}" \
+                     -authkeyPath=${lib.escapeShellArg value.authKeyPath} \
+                     -insecureHTTPS=${lib.boolToString value.insecureHTTPS} \
+                     -suppressWhois=${lib.boolToString value.suppressWhois} \
                      ${
                 if value.whoisTimeout != null
-                then "-whoisTimeout=${value.whoisTimeout}"
+                then "-whoisTimeout=${lib.escapeShellArg value.whoisTimeout}"
                 else ""
               } \
                      ${
                 if value.downstreamUnixAddr != null
-                then "-downstreamUnixAddr=${value.downstreamUnixAddr}"
+                then "-downstreamUnixAddr=${lib.escapeShellArg value.downstreamUnixAddr}"
                 else ""
               } \
               ${
-                lib.concatMapStringsSep " \\\n" (p: "-prefix \"${p}\"") value.prefixes
+                lib.concatMapStringsSep " \\\n" (p: "-prefix ${lib.escapeShellArg p}") value.prefixes
               } \
               ${
                 lib.concatMapStringsSep " \\\n" (p: "-upstreamHeader ${lib.escapeShellArg p}") (lib.mapAttrsToList (name: value: "${name}: ${value}") value.upstreamHeaders)

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -71,7 +71,7 @@
             default = false;
           };
 
-          downstreamUnixAddr = mkOption {
+          upstreamUnixAddr = mkOption {
             description = "Connect only to the given UNIX Domain Socket";
             type = types.nullOr types.path;
             default = null;
@@ -150,8 +150,8 @@
                 else ""
               } \
                      ${
-                if value.downstreamUnixAddr != null
-                then "-downstreamUnixAddr=${lib.escapeShellArg value.downstreamUnixAddr}"
+                if value.upstreamUnixAddr != null
+                then "-upstreamUnixAddr=${lib.escapeShellArg value.upstreamUnixAddr}"
                 else ""
               } \
               ${

--- a/proxy.go
+++ b/proxy.go
@@ -88,7 +88,6 @@ func (s *validTailnetSrv) rewrite(r *httputil.ProxyRequest) {
 		r.Out.URL.Path = s.DestURL.Path
 	}
 
-	// Set known proxy headers:
 	r.SetXForwarded()
 	if s.RecommendedProxyHeaders {
 		if r.In.TLS == nil {
@@ -109,6 +108,11 @@ func (s *validTailnetSrv) rewrite(r *httputil.ProxyRequest) {
 			r.Out.Header.Set("X-Forwarded-Port", port)
 		}
 	}
+
+	for h, vals := range s.UpstreamHeaders {
+		r.Out.Header[h] = vals
+	}
+
 	who := s.setWhoisHeaders(r)
 	r.Out = r.Out.WithContext(context.WithValue(r.Out.Context(), proxyContextKey, &proxyContext{
 		start:        time.Now(),


### PR DESCRIPTION
This lets users set custom headers (with a constant value) in case they need to talk to a weirdo service that requires headers outside the ones we set by default.

Also fixes an annoying issue I introduced very early on: I'd mistaken "upstream" for "downstream" and named some upstream-related things "downstream". Here we're fixing that naming and calling everything to do with the backend "upstream".