### PR TITLE
New option -suppressTailnetDialer, to help access off-tailnet addresses

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -107,6 +107,12 @@
             default = {};
           };
 
+          suppressTailnetDialer = mkOption {
+            description = "Disable using the tsnet-provided dialer, which can sometimes cause issues hitting addresses outside the tailnet";
+            type = types.bool;
+            default = false;
+          };
+
           toURL = mkOption {
             description = "URL to forward HTTP requests to";
             type = types.str;
@@ -144,6 +150,7 @@
                      -authkeyPath=${lib.escapeShellArg value.authKeyPath} \
                      -insecureHTTPS=${lib.boolToString value.insecureHTTPS} \
                      -suppressWhois=${lib.boolToString value.suppressWhois} \
+                     -suppressTailnetDialer=${lib.boolToString value.suppressTailnetDialer} \
                      ${
                 if value.whoisTimeout != null
                 then "-whoisTimeout=${lib.escapeShellArg value.whoisTimeout}"


### PR DESCRIPTION
It looks like upstreams on private VLANs on my network can't be reached via the tailscale dialer. Using the non-tailscale dialer to does allow tsnsrv to reach those machines.

To this end, PR adds a `-suppressTailnetDialer=true` flag, which will use the stdlib `net.Dialer` to dial out, which _can_ reach those upstreams. It's weird, but it works!