### PR TITLE
Don't attempt to set identities from a missing identity

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -146,6 +146,7 @@ func (s *validTailnetSrv) setWhoisHeaders(r *httputil.ProxyRequest) *apitype.Who
 			"error", err,
 			"request", r.In,
 		)
+		return nil
 	}
 	h := r.Out.Header
 	h.Set("X-Tailscale-User", who.UserProfile.ID.String())


### PR DESCRIPTION
When we fail to look up a tailscale identity, previously this would dereference nil in an attempt to get at the identity fields. Let's not do that & instead return early.