### PR TITLE
Add prometheus sideband HTTP server route for submitting a tailscale bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,18 @@ Once you have a oauth client (and a command line) with these
 requirements, all you need to do is to use the client _secret_ (the
 client ID is irrelevant for us) as the tailscale auth key and tsnsrv
 will do the rest.
+
+### Submitting tailscale bug reports
+
+If you run into issues that look like bugs in the tailscale service or the
+tsnet library itself, you might want to submit a tailscale bug report. That 
+can be done with the following steps:
+
+1. Turn on the tsnsrv `-enableBugReports` flag
+2. POST to `/bugreport` on the prometheus API endpoint:
+   `curl -X POST http://your-tsnsrv-instance-name.your-tailnet.ts.net:9099/bugreport`
+   (making sure to replace `your-tsnsrv-instance` and `your-tailnet` and `9099` 
+   with the names of your tsnsrv service, your tailnet name and your prometheusAddr port).
+3. `curl` will return a bug report ID and tsnsrv will log the report ID at INFO level.
+   When you file a tailscale bug, include any relevant report IDs you generated so they
+   can check your debug logs.

--- a/cli.go
+++ b/cli.go
@@ -162,6 +162,7 @@ type TailnetSrv struct {
 	WhoisTimeout                      time.Duration
 	SuppressWhois                     bool
 	PrometheusAddr                    string
+	EnableBugReports                  bool
 	UpstreamHeaders                   headers
 	SuppressTailnetDialer             bool
 	ReadHeaderTimeout                 time.Duration
@@ -203,6 +204,7 @@ func TailnetSrvFromArgs(args []string) (*ValidTailnetSrv, *ffcli.Command, error)
 	fs.DurationVar(&s.WhoisTimeout, "whoisTimeout", 1*time.Second, "Maximum amount of time to spend looking up client identities")
 	fs.BoolVar(&s.SuppressWhois, "suppressWhois", false, "Do not set X-Tailscale-User-* headers in upstream requests")
 	fs.StringVar(&s.PrometheusAddr, "prometheusAddr", ":9099", "Serve prometheus metrics from this address. Empty string to disable.")
+	fs.BoolVar(&s.EnableBugReports, "enableBugReports", false, "Allow POST /bugreport on the prometheus address to submit debug logs to the Tailscale API")
 	fs.Var(&s.UpstreamHeaders, "upstreamHeader", "Additional headers (separated by ': ') on requests to upstream.")
 	fs.BoolVar(&s.SuppressTailnetDialer, "suppressTailnetDialer", false, "Whether to use the stdlib net.Dialer instead of a tailnet-enabled one")
 	fs.DurationVar(&s.ReadHeaderTimeout, "readHeaderTimeout", 0, "Amount of time to allow for reading HTTP request headers. 0 will disable the timeout but expose the service to the slowloris attack.")
@@ -458,6 +460,20 @@ func (s *ValidTailnetSrv) setupPrometheus(srv *tsnet.Server) error {
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
+	if s.EnableBugReports {
+		mux.HandleFunc("POST /bugreport", func(w http.ResponseWriter, r *http.Request) {
+			lcl, err := srv.LocalClient()
+			if err != nil {
+				slog.Error("failed to retrieve local tailscale client", "error", err)
+			}
+			reportID, err := lcl.BugReport(r.Context(), "")
+			if err != nil {
+				slog.Error("failed to submit bug report logs to tailscale API", "error", err)
+			}
+			slog.Info("Submitted bug report logs to tailscale API", "report", reportID)
+			_, _ = w.Write([]byte(reportID))
+		})
+	}
 	listener, err := srv.Listen("tcp", s.PrometheusAddr)
 	if err != nil {
 		return fmt.Errorf("could not listen on prometheus address %v: %w", s.PrometheusAddr, err)

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -49,185 +49,194 @@
 
   serviceSubmodule = with lib; let
     inherit (config.services.tsnsrv) defaults;
-  in ({config, ...}: {
-    options = {
-      authKeyPath = mkOption {
-        description = "Path to a file containing a tailscale auth key. Make this a secret";
-        type = types.path;
-        default = defaults.authKeyPath;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.authKeyPath";
-      };
+  in (
+    {config, ...}: {
+      options = {
+        authKeyPath = mkOption {
+          description = "Path to a file containing a tailscale auth key. Make this a secret";
+          type = types.path;
+          default = defaults.authKeyPath;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.authKeyPath";
+        };
 
-      ephemeral = mkOption {
-        description = "Delete the tailnet participant shortly after it goes offline";
-        type = types.bool;
-        default = defaults.ephemeral;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.ephemeral";
-      };
+        ephemeral = mkOption {
+          description = "Delete the tailnet participant shortly after it goes offline";
+          type = types.bool;
+          default = defaults.ephemeral;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.ephemeral";
+        };
 
-      funnel = mkOption {
-        description = "Serve HTTP as a funnel, meaning that it is available on the public internet.";
-        type = types.bool;
-        default = false;
-      };
+        funnel = mkOption {
+          description = "Serve HTTP as a funnel, meaning that it is available on the public internet.";
+          type = types.bool;
+          default = false;
+        };
 
-      insecureHTTPS = mkOption {
-        description = "Disable TLS certificate validation for requests from upstream. Insecure.";
-        type = types.bool;
-        default = false;
-      };
+        insecureHTTPS = mkOption {
+          description = "Disable TLS certificate validation for requests from upstream. Insecure.";
+          type = types.bool;
+          default = false;
+        };
 
-      listenAddr = mkOption {
-        description = "Address to listen on";
-        type = types.str;
-        default = defaults.listenAddr;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.listenAddr";
-      };
+        listenAddr = mkOption {
+          description = "Address to listen on";
+          type = types.str;
+          default = defaults.listenAddr;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.listenAddr";
+        };
 
-      loginServerUrl = lib.mkOption {
-        description = "Login server URL to use. If unset, defaults to the official tailscale service.";
-        default = defaults.loginServerUrl;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.loginServerUrl";
-        type = with types; nullOr str;
-      };
+        loginServerUrl = lib.mkOption {
+          description = "Login server URL to use. If unset, defaults to the official tailscale service.";
+          default = defaults.loginServerUrl;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.loginServerUrl";
+          type = with types; nullOr str;
+        };
 
-      package = mkOption {
-        description = "Package to use for this tsnsrv service.";
-        default = defaults.package;
-        type = types.package;
-      };
+        package = mkOption {
+          description = "Package to use for this tsnsrv service.";
+          default = defaults.package;
+          type = types.package;
+        };
 
-      plaintext = mkOption {
-        description = "Whether to serve non-TLS-encrypted plaintext HTTP";
-        type = types.bool;
-        default = false;
-      };
+        plaintext = mkOption {
+          description = "Whether to serve non-TLS-encrypted plaintext HTTP";
+          type = types.bool;
+          default = false;
+        };
 
-      certificateFile = mkOption {
-        description = "Custom certificate file to use for TLS listening instead of Tailscale's builtin way";
-        type = with types; nullOr path;
-        default = defaults.certificateFile;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.certificateFile";
-      };
+        certificateFile = mkOption {
+          description = "Custom certificate file to use for TLS listening instead of Tailscale's builtin way";
+          type = with types; nullOr path;
+          default = defaults.certificateFile;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.certificateFile";
+        };
 
-      certificateKey = mkOption {
-        description = "Custom key file to use for TLS listening instead of Tailscale's builtin way.";
-        type = with types; nullOr path;
-        default = defaults.certificateKey;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.certificateKey";
-      };
+        certificateKey = mkOption {
+          description = "Custom key file to use for TLS listening instead of Tailscale's builtin way.";
+          type = with types; nullOr path;
+          default = defaults.certificateKey;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.certificateKey";
+        };
 
-      acmeHost = mkOption {
-        description = "Populate certificateFile and certificateKey option from this certificate name from security.acme module.";
-        type = with types; nullOr str;
-        default = defaults.acmeHost;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.acmeHost";
-      };
+        acmeHost = mkOption {
+          description = "Populate certificateFile and certificateKey option from this certificate name from security.acme module.";
+          type = with types; nullOr str;
+          default = defaults.acmeHost;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.acmeHost";
+        };
 
-      upstreamUnixAddr = mkOption {
-        description = "Connect only to the given UNIX Domain Socket";
-        type = types.nullOr types.path;
-        default = null;
-      };
+        upstreamUnixAddr = mkOption {
+          description = "Connect only to the given UNIX Domain Socket";
+          type = types.nullOr types.path;
+          default = null;
+        };
 
-      prefixes = mkOption {
-        description = "URL path prefixes to allow in forwarding. Acts as an allowlist but if no prefixes are set, all prefixes are allowed.";
-        type = types.listOf (types.strMatching "^(/|tailnet:/|funnel:/).*");
-        default = [];
-        example = ["tailnet:/" "funnel:/.well-known/"];
-      };
+        prefixes = mkOption {
+          description = "URL path prefixes to allow in forwarding. Acts as an allowlist but if no prefixes are set, all prefixes are allowed.";
+          type = types.listOf (types.strMatching "^(/|tailnet:/|funnel:/).*");
+          default = [];
+          example = [
+            "tailnet:/"
+            "funnel:/.well-known/"
+          ];
+        };
 
-      stripPrefix = mkOption {
-        description = "Strip matched prefix from request to upstream. Probably should be true when allowlisting multiple prefixes.";
-        type = types.bool;
-        default = true;
-      };
+        stripPrefix = mkOption {
+          description = "Strip matched prefix from request to upstream. Probably should be true when allowlisting multiple prefixes.";
+          type = types.bool;
+          default = true;
+        };
 
-      whoisTimeout = mkOption {
-        description = "Maximum amount of time that a requestor lookup may take.";
-        type = types.nullOr types.str;
-        default = null;
-      };
+        whoisTimeout = mkOption {
+          description = "Maximum amount of time that a requestor lookup may take.";
+          type = types.nullOr types.str;
+          default = null;
+        };
 
-      suppressWhois = mkOption {
-        description = "Disable passing requestor information to upstream service";
-        type = types.bool;
-        default = false;
-      };
+        suppressWhois = mkOption {
+          description = "Disable passing requestor information to upstream service";
+          type = types.bool;
+          default = false;
+        };
 
-      upstreamHeaders = mkOption {
-        description = "Headers to set on requests to upstream.";
-        type = types.attrsOf types.str;
-        default = {};
-      };
+        upstreamHeaders = mkOption {
+          description = "Headers to set on requests to upstream.";
+          type = types.attrsOf types.str;
+          default = {};
+        };
 
-      suppressTailnetDialer = mkOption {
-        description = "Disable using the tsnet-provided dialer, which can sometimes cause issues hitting addresses outside the tailnet";
-        type = types.bool;
-        default = false;
-      };
+        suppressTailnetDialer = mkOption {
+          description = "Disable using the tsnet-provided dialer, which can sometimes cause issues hitting addresses outside the tailnet";
+          type = types.bool;
+          default = false;
+        };
 
-      readHeaderTimeout = mkOption {
-        description = "";
-        type = types.nullOr types.str;
-        default = null;
-      };
+        readHeaderTimeout = mkOption {
+          description = "";
+          type = types.nullOr types.str;
+          default = null;
+        };
 
-      urlParts = mkOption {
-        description = "URL parts that make up an alternative to the toURL option.";
-        type = types.nullOr (types.submodule urlPartsSubmoduleWithDefaults);
-        default = null;
-      };
+        urlParts = mkOption {
+          description = "URL parts that make up an alternative to the toURL option.";
+          type = types.nullOr (types.submodule urlPartsSubmoduleWithDefaults);
+          default = null;
+        };
 
-      toURL = mkOption {
-        description = "URL to forward HTTP requests to. Either this or the urlParts option must be set.";
-        type = types.str;
-        default = "${config.urlParts.protocol}://${config.urlParts.host}:${toString config.urlParts.port}";
-        defaultText = lib.literalExpression "\${config.services.tsnsrv.<name>.urlParts.protocol}://\${config.services.tsnsrv.<name>.urlParts.host}:\${toString config.services.tsnsrv.<name>.urlParts.port}";
-      };
+        toURL = mkOption {
+          description = "URL to forward HTTP requests to. Either this or the urlParts option must be set.";
+          type = types.str;
+          default = "${config.urlParts.protocol}://${config.urlParts.host}:${toString config.urlParts.port}";
+          defaultText = lib.literalExpression "\${config.services.tsnsrv.<name>.urlParts.protocol}://\${config.services.tsnsrv.<name>.urlParts.host}:\${toString config.services.tsnsrv.<name>.urlParts.port}";
+        };
 
-      supplementalGroups = mkOption {
-        description = "List of groups to run the service under (in addition to the 'tsnsrv' group)";
-        type = types.listOf types.str;
-        default = defaults.supplementalGroups;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.supplementalGroups";
-      };
+        supplementalGroups = mkOption {
+          description = "List of groups to run the service under (in addition to the 'tsnsrv' group)";
+          type = types.listOf types.str;
+          default = defaults.supplementalGroups;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.supplementalGroups";
+        };
 
-      tags = mkOption {
-        description = "Tags for minting an auth key from an OAuth2 client. Must be prefixed with `tag:`";
-        type = types.listOf (types.strMatching "^tag:.*");
-        default = defaults.tags;
-        example = ["tag:foo" "tag:bar"];
-      };
+        tags = mkOption {
+          description = "Tags for minting an auth key from an OAuth2 client. Must be prefixed with `tag:`";
+          type = types.listOf (types.strMatching "^tag:.*");
+          default = defaults.tags;
+          example = [
+            "tag:foo"
+            "tag:bar"
+          ];
+        };
 
-      timeout = mkOption {
-        description = "Maximum amount of time that authenticating to the tailscale API may take";
-        type = with types; nullOr str;
-        default = defaults.timeout;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.timeout";
-      };
+        timeout = mkOption {
+          description = "Maximum amount of time that authenticating to the tailscale API may take";
+          type = with types; nullOr str;
+          default = defaults.timeout;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.timeout";
+        };
 
-      tsnetVerbose = mkOption {
-        description = "Whether to log verbosely from tsnet. Can be useful for seeing first-time authentication URLs.";
-        type = types.bool;
-        default = defaults.tsnetVerbose;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.tsnetVerbose";
-      };
+        tsnetVerbose = mkOption {
+          description = "Whether to log verbosely from tsnet. Can be useful for seeing first-time authentication URLs.";
+          type = types.bool;
+          default = defaults.tsnetVerbose;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.tsnetVerbose";
+        };
 
-      upstreamAllowInsecureCiphers = mkOption {
-        description = "Whether to allow the upstream to have only ciphersuites that don't offer Perfect Forward Secrecy. If a connection attempt to an upstream returns the error `remote error: tls: handshake failure`, try setting this to true.";
-        type = types.bool;
-        default = defaults.upstreamAllowInsecureCiphers;
-        defaultText = lib.literalExpression "config.services.tsnsrv.defaults.upstreamAllowInsecureCiphers";
-      };
+        upstreamAllowInsecureCiphers = mkOption {
+          description = "Whether to allow the upstream to have only ciphersuites that don't offer Perfect Forward Secrecy. If a connection attempt to an upstream returns the error `remote error: tls: handshake failure`, try setting this to true.";
+          type = types.bool;
+          default = defaults.upstreamAllowInsecureCiphers;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.upstreamAllowInsecureCiphers";
+        };
 
-      extraArgs = mkOption {
-        description = "Extra arguments to pass to this tsnsrv process.";
-        type = types.listOf types.str;
-        default = [];
+        extraArgs = mkOption {
+          description = "Extra arguments to pass to this tsnsrv process.";
+          type = types.listOf types.str;
+          default = defaults.extraArgs;
+          defaultText = lib.literalExpression "config.services.tsnsrv.defaults.extraArgs";
+        };
       };
-    };
-  });
+    }
+  );
 
   serviceArgs = {
     name,
@@ -254,8 +263,14 @@
       "-tsnetVerbose=${lib.boolToString service.tsnetVerbose}"
       "-upstreamAllowInsecureCiphers=${lib.boolToString service.upstreamAllowInsecureCiphers}"
     ]
-    ++ lib.optionals (service.whoisTimeout != null) ["-whoisTimeout" service.whoisTimeout]
-    ++ lib.optionals (service.upstreamUnixAddr != null) ["-upstreamUnixAddr" service.upstreamUnixAddr]
+    ++ lib.optionals (service.whoisTimeout != null) [
+      "-whoisTimeout"
+      service.whoisTimeout
+    ]
+    ++ lib.optionals (service.upstreamUnixAddr != null) [
+      "-upstreamUnixAddr"
+      service.upstreamUnixAddr
+    ]
     ++ lib.optionals (service.certificateFile != null && service.certificateKey != null) [
       "-certificateFile=${service.certificateFile}"
       "-keyFile=${service.certificateKey}"
@@ -263,7 +278,9 @@
     ++ lib.optionals (service.timeout != null) ["-timeout=${service.timeout}"]
     ++ map (t: "-tag=${t}") service.tags
     ++ map (p: "-prefix=${p}") service.prefixes
-    ++ map (h: "-upstreamHeader=${h}") (lib.mapAttrsToList (name: service: "${name}: ${service}") service.upstreamHeaders)
+    ++ map (h: "-upstreamHeader=${h}") (
+      lib.mapAttrsToList (name: service: "${name}: ${service}") service.upstreamHeaders
+    )
     ++ service.extraArgs
     ++ [service.toURL];
 in {
@@ -332,7 +349,10 @@ in {
         description = "Tags for minting an auth key from an OAuth2 client. Must be prefixed with `tag:`";
         type = types.listOf (types.strMatching "^tag:.*");
         default = [];
-        example = ["tag:foo" "tag:bar"];
+        example = [
+          "tag:foo"
+          "tag:bar"
+        ];
       };
 
       timeout = mkOption {
@@ -357,6 +377,12 @@ in {
         description = "Default URL parts for tsnsrv services. Each service will have the parts here interpolated onto its .toURL option by default.";
         type = types.submodule urlPartsSubmodule;
       };
+
+      extraArgs = mkOption {
+        description = "Extra arguments to pass to each tsnsrv service process.";
+        type = types.listOf types.str;
+        default = [];
+      };
     };
 
     services.tsnsrv.services = mkOption {
@@ -378,25 +404,27 @@ in {
 
       containers = mkOption {
         description = "Attrset mapping sidecar container names to their respective tsnsrv service definition. Each sidecar container will be attached to the container it belongs to, sharing its network.";
-        type = types.attrsOf (types.submodule {
-          options = {
-            name = mkOption {
-              description = "Name to use for the tsnet service. This defaults to the container name.";
-              type = types.nullOr types.str;
-              default = null;
-            };
+        type = types.attrsOf (
+          types.submodule {
+            options = {
+              name = mkOption {
+                description = "Name to use for the tsnet service. This defaults to the container name.";
+                type = types.nullOr types.str;
+                default = null;
+              };
 
-            forContainer = mkOption {
-              description = "The container to which to attach the sidecar.";
-              type = types.str; # TODO: see if we can constrain this to all the oci containers in the system definition, with types.oneOf or an appropriate check.
-            };
+              forContainer = mkOption {
+                description = "The container to which to attach the sidecar.";
+                type = types.str; # TODO: see if we can constrain this to all the oci containers in the system definition, with types.oneOf or an appropriate check.
+              };
 
-            service = mkOption {
-              description = "tsnsrv service definition for the sidecar.";
-              type = types.submodule serviceSubmodule;
+              service = mkOption {
+                description = "tsnsrv service definition for the sidecar.";
+                type = types.submodule serviceSubmodule;
+              };
             };
-          };
-        });
+          }
+        );
       };
     };
   };
@@ -432,12 +460,15 @@ in {
     };
   in
     lib.mkMerge [
-      (lib.mkIf (config.services.tsnsrv.enable || config.virtualisation.oci-sidecars.tsnsrv.enable)
-        {users.groups.tsnsrv = {};})
+      (lib.mkIf (config.services.tsnsrv.enable || config.virtualisation.oci-sidecars.tsnsrv.enable) {
+        users.groups.tsnsrv = {};
+      })
       (lib.mkIf config.services.tsnsrv.enable {
         assertions =
           lib.mapAttrsToList (name: service: {
-            assertion = ((service.certificateFile != null) && (service.certificateKey != null)) || ((service.certificateFile == null) && (service.certificateKey == null));
+            assertion =
+              ((service.certificateFile != null) && (service.certificateKey != null))
+              || ((service.certificateFile == null) && (service.certificateKey == null));
             message = "Both certificateFile and certificateKey must either be set or null on services.tsnsrv.services.${name}";
           })
           config.services.tsnsrv.services;
@@ -445,42 +476,44 @@ in {
         systemd.services =
           lib.mapAttrs' (
             name: service':
-              lib.nameValuePair
-              "tsnsrv-${name}"
-              (let
-                service =
-                  service'
-                  // lib.optionalAttrs (service'.acmeHost != null) {
-                    certificateFile = "${config.security.acme.certs.${service.acmeHost}.directory}/fullchain.pem";
-                    certificateKey = "${config.security.acme.certs.${service.acmeHost}.directory}/key.pem";
-                  };
-              in {
-                wantedBy = ["multi-user.target"];
-                after = ["network-online.target"];
-                wants = ["network-online.target"];
-                script = ''
-                  exec ${lib.getExe service.package} \
-                    "-stateDir=$STATE_DIRECTORY/tsnet-tsnsrv" \
-                    "-authkeyPath=$CREDENTIALS_DIRECTORY/authKey" \
-                    ${lib.escapeShellArgs (serviceArgs {inherit name service;})}
-                '';
-                stopIfChanged = false;
-                serviceConfig =
-                  {
-                    DynamicUser = true;
-                    Restart = "always";
-                    SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ service.supplementalGroups;
-                    StateDirectory = "tsnsrv-${name}";
-                    StateDirectoryMode = "0700";
-                    LoadCredential = [
-                      "authKey:${service.authKeyPath}"
-                    ];
-                  }
-                  // lib.optionalAttrs (service.loginServerUrl != null) {
-                    Environment = "TS_URL=${service.loginServerUrl}";
-                  }
-                  // lockedDownserviceConfig;
-              })
+              lib.nameValuePair "tsnsrv-${name}" (
+                let
+                  service =
+                    service'
+                    // lib.optionalAttrs (service'.acmeHost != null) {
+                      certificateFile = "${config.security.acme.certs.${service.acmeHost}.directory}/fullchain.pem";
+                      certificateKey = "${config.security.acme.certs.${service.acmeHost}.directory}/key.pem";
+                    };
+                in {
+                  wantedBy = ["multi-user.target"];
+                  after = ["network-online.target"];
+                  wants = ["network-online.target"];
+                  script = ''
+                    exec ${lib.getExe service.package} \
+                      "-stateDir=$STATE_DIRECTORY/tsnet-tsnsrv" \
+                      "-authkeyPath=$CREDENTIALS_DIRECTORY/authKey" \
+                      ${lib.escapeShellArgs (serviceArgs {
+                      inherit name service;
+                    })}
+                  '';
+                  stopIfChanged = false;
+                  serviceConfig =
+                    {
+                      DynamicUser = true;
+                      Restart = "always";
+                      SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ service.supplementalGroups;
+                      StateDirectory = "tsnsrv-${name}";
+                      StateDirectoryMode = "0700";
+                      LoadCredential = [
+                        "authKey:${service.authKeyPath}"
+                      ];
+                    }
+                    // lib.optionalAttrs (service.loginServerUrl != null) {
+                      Environment = "TS_URL=${service.loginServerUrl}";
+                    }
+                    // lockedDownserviceConfig;
+                }
+              )
           )
           config.services.tsnsrv.services;
       })
@@ -513,7 +546,10 @@ in {
                 TS_URL = sidecar.service.loginServerUrl;
               };
               cmd =
-                ["-stateDir=/state" "-authkeyPath=${credentialsDir}/authKey"]
+                [
+                  "-stateDir=/state"
+                  "-authkeyPath=${credentialsDir}/authKey"
+                ]
                 ++ (serviceArgs {
                   name =
                     if sidecar.name == null
@@ -528,22 +564,24 @@ in {
         systemd.services =
           (
             # systemd unit settings for the respective podman services:
-            lib.mapAttrs' (name: sidecar: let
-              serviceName = "${config.virtualisation.oci-containers.backend}-${name}";
-            in {
-              name = serviceName;
-              value = {
-                path = ["/run/wrappers"];
-                serviceConfig = {
-                  StateDirectory = serviceName;
-                  StateDirectoryMode = "0700";
-                  SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ sidecar.service.supplementalGroups;
-                  LoadCredential = [
-                    "authKey:${sidecar.service.authKeyPath}"
-                  ];
+            lib.mapAttrs' (
+              name: sidecar: let
+                serviceName = "${config.virtualisation.oci-containers.backend}-${name}";
+              in {
+                name = serviceName;
+                value = {
+                  path = ["/run/wrappers"];
+                  serviceConfig = {
+                    StateDirectory = serviceName;
+                    StateDirectoryMode = "0700";
+                    SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ sidecar.service.supplementalGroups;
+                    LoadCredential = [
+                      "authKey:${sidecar.service.authKeyPath}"
+                    ];
+                  };
                 };
-              };
-            })
+              }
+            )
             config.virtualisation.oci-sidecars.tsnsrv.containers
           )
           // (
@@ -551,13 +589,17 @@ in {
             # Ensure that the sidecar is up when the "main" container is up.
             lib.foldAttrs (item: acc: {unitConfig.Upholds = acc.unitConfig.Upholds ++ ["${item}.service"];})
             {unitConfig.Upholds = [];}
-            (lib.mapAttrsToList (name: sidecar: let
-                fromServiceName = "${config.virtualisation.oci-containers.backend}-${sidecar.forContainer}";
-                toServiceName = "${config.virtualisation.oci-containers.backend}-${name}";
-              in {
-                "${fromServiceName}" = toServiceName;
-              })
-              config.virtualisation.oci-sidecars.tsnsrv.containers)
+            (
+              lib.mapAttrsToList (
+                name: sidecar: let
+                  fromServiceName = "${config.virtualisation.oci-containers.backend}-${sidecar.forContainer}";
+                  toServiceName = "${config.virtualisation.oci-containers.backend}-${name}";
+                in {
+                  "${fromServiceName}" = toServiceName;
+                }
+              )
+              config.virtualisation.oci-sidecars.tsnsrv.containers
+            )
           );
       })
     ];


### PR DESCRIPTION
On occasion, I find what appears to be funnel-related bugs, so here's an optional (defaulting to off) route that allows submitting a tailscale bug.